### PR TITLE
[Fix] Select 컴포넌트에서 Type 오류 발생한 부분 수정

### DIFF
--- a/src/components/commons/Select/Select.tsx
+++ b/src/components/commons/Select/Select.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactSelect, { Props as ReactSelectProps } from 'react-select';
 import styles from './Select.module.css';
 
-interface Option<OptionType extends string> {
+interface Option<OptionType> {
   value: OptionType;
   label: OptionType;
 }
@@ -17,7 +17,7 @@ interface SelectProps<OptionType>
   onChange: (option: OptionType) => void;
 }
 
-const Select = <OptionType extends string>({
+const Select = <OptionType,>({
   labelText = '',
   options,
   onChange,
@@ -26,7 +26,7 @@ const Select = <OptionType extends string>({
   return (
     <div className={styles.selectContainer}>
       {labelText && <label>{labelText}</label>}
-      <ReactSelect
+      <ReactSelect<Option<OptionType>, false>
         classNames={{
           container: () => styles.select,
           control: (state) => {
@@ -40,7 +40,7 @@ const Select = <OptionType extends string>({
         }}
         options={options.map((option) => ({ value: option, label: option }))}
         onChange={(changeValue: Option<OptionType> | null) => {
-          onChange(changeValue?.value);
+          onChange(changeValue?.value || options[0]);
         }}
         {...props}
       />


### PR DESCRIPTION
## 🧾 설명

React Select를 처음 사용하다보니 Type을 별도로 지정해주어야한다는 것을 몰랐고, 공식 문서 및 구글링을 통해 방법을 찾아보았습니다.

## ✅ 작업 내용

- [x] Option 및 SelectProps에 대한 Type 명시

## #️⃣ 관련 이슈

- Closes #12 

## 💭 기타
