### PR TITLE
[Fix] Preview 컴포넌트에서 Type 오류 발생한 부분 수정

### DIFF
--- a/src/pages/EditPage/commons/Block/Block.tsx
+++ b/src/pages/EditPage/commons/Block/Block.tsx
@@ -3,7 +3,7 @@ import { useConsole } from '../../../../context/consoleContext.tsx';
 import type { ConsoleBlock } from '../../../../types/console.ts';
 import styles from './Block.module.css';
 
-interface CommonBlockProps extends ConsoleBlock {
+interface CommonBlockProps extends Partial<ConsoleBlock> {
   className?: string;
   onClick?: () => void;
 }


### PR DESCRIPTION
## 🧾 설명

Preview 페이지에서 사용하는 Block은 id가 필요하지 않지만, ConsoleBlock 타입에서 id가 필수 값으로 되어있어 발생한 오류를 수정했습니다.

## ✅ 작업 내용

- [x] ConsoleBlock을 Optional로 변경

## #️⃣ 관련 이슈

- closes #17 

## 💭 기타
