### PR TITLE
[HOTFIX] updateAt 저장 형식 수정

### DIFF
--- a/src/storages/consoleStorage.ts
+++ b/src/storages/consoleStorage.ts
@@ -16,7 +16,7 @@ const createConsole = () => {
     id,
     title: '',
     description: '',
-    updatedAt: moment().format('YYYY-MM-DD hh:mm:ss'),
+    updatedAt: moment().format('YYYY-MM-DD HH:mm:ss'),
     console: [[]],
   };
   saveToStorage();


### PR DESCRIPTION
## 🧾 설명

updatedAt이 오전에 테스트 할 때에는 오류가 없었지만, 오후에 테스트해보니 시간 저장 방식 중 hour이 정상적으로 저장되지 않는 오류를 발견했고, 기존에 저장하던 방식인 `hh`가 12시간 방식으로 표시하는 방법이라 24시간을 표시하기 위해 `HH`로 변경했습니다.

## 💭 기타
